### PR TITLE
paho-mqtt Update

### DIFF
--- a/overseer.py
+++ b/overseer.py
@@ -31,7 +31,7 @@ countdown_ms = 3200
 # local broker address, if the server runs on the same PC as the client never change it
 broker = "127.0.0.1"
 port = 1884
-client = mqtt.Client("Master PC")
+client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, "Master PC")
 
 
 def main():  # main method where the MQTT client is connected


### PR DESCRIPTION
The latest version of paho-mqtt API broke some code. Adding an extra parameter to mqtt.Client() solves the issue. Additional changes can be found here: https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html